### PR TITLE
Adding kms key id toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_iam_group_name"></a> [iam\_group\_name](#input\_iam\_group\_name) | Name of the IAM group Okta IAM policies will be attached to | `string` | `"okta-sso"` | no |
 | <a name="input_iam_user_name"></a> [iam\_user\_name](#input\_iam\_user\_name) | Username for the Okta service account | `string` | `"okta-sso"` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | kms key id to encrypt Okta Secret | `string` | `""` | no |
 | <a name="input_saml_providers"></a> [saml\_providers](#input\_saml\_providers) | A map of SAML provider names and metadata | `map(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to supported resources | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "aws_iam_access_key" "this" {
 resource "aws_secretsmanager_secret" "this" {
   name_prefix = "terraform-okta-sso"
   description = "Okta SSO user access key"
+  kms_key_id = var.kms_key_id
   tags        = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_iam_access_key" "this" {
 resource "aws_secretsmanager_secret" "this" {
   name_prefix = "terraform-okta-sso"
   description = "Okta SSO user access key"
-  kms_key_id = var.kms_key_id
+  kms_key_id  = var.kms_key_id
   tags        = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "iam_user_name" {
   type        = string
 }
 
+variable "kms_key_id" {
+  default = ""
+  description = "kms key id to encrypt Okta Secret"
+  type = string
+ }
+
 variable "saml_providers" {
   description = "A map of SAML provider names and metadata"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,10 @@ variable "iam_user_name" {
 }
 
 variable "kms_key_id" {
-  default = ""
+  default     = ""
   description = "kms key id to encrypt Okta Secret"
-  type = string
- }
+  type        = string
+}
 
 variable "saml_providers" {
   description = "A map of SAML provider names and metadata"


### PR DESCRIPTION
This adds the option to encrypt the kms secret for Okta.

I tested it using the "" default against an already-deployed version of this and there was no deltas. 